### PR TITLE
Refactored teleop control from custom command groups to built-in Scheduler.

### DIFF
--- a/src/robot.py
+++ b/src/robot.py
@@ -21,9 +21,6 @@ class Robot(CommandBasedRobot):
         self.updateodemetry = updateodemetry.UpdateOdemetry()
         # Set command group member variables
         self.autonomous = autogroup.AutonomousCommandGroup()
-        self.disabled = disabledgroup.DisabledCommandGroup()
-        self.teleop = teleopgroup.TeleopCommandGroup()
-        self.test = testgroup.TestCommandGroup()
 
     def globalInit(self):
         """Run on every init"""
@@ -32,7 +29,6 @@ class Robot(CommandBasedRobot):
     def disabledInit(self):
         """Run when robot enters disabled mode"""
         self.globalInit()
-        self.disabled.start()
 
     def autonomousInit(self):
         """Run when the robot enters auto mode"""
@@ -42,12 +38,10 @@ class Robot(CommandBasedRobot):
     def teleopInit(self):
         """Run when the robot enters teleop mode"""
         self.globalInit()
-        self.teleop.start()
 
     def testInit(self):
         """Run when the robot enters test mode"""
         self.globalInit()
-        self.test.start()
 
 
 # defining main function

--- a/src/subsystems/drive.py
+++ b/src/subsystems/drive.py
@@ -2,7 +2,7 @@ import ctre
 
 from constants import Constants
 from utils import singleton
-from commands import tankdrive
+from commands.tankdrive import TankDrive
 from wpilib.command import Subsystem
 from wpilib import adxrs450_gyro
 
@@ -33,6 +33,9 @@ class Drive(Subsystem, metaclass=singleton.Singleton):
             ctre.ControlMode.Follower, Constants.RIGHT_MOTOR_MASTER_ID)
         self.left_motor_slave.set(ctre.ControlMode.Follower,
                                   Constants.LEFT_MOTOR_MASTER_ID)
+
+    def initDefaultCommand(self):
+        self.setDefaultCommand(TankDrive())
 
     def zeroSensors(self):
         self.left_motor_master.setSelectedSensorPosition(0, 0, 0)


### PR DESCRIPTION
The RobotPy [example](https://github.com/robotpy/examples/tree/master/command-based) for a command-based robot **does** create a command group for an autonomous program. However, I don't believe this same structure should be used to schedule commands for teleop control.

The purpose of command groups is to manually schedule commands in a sequential or parallel sequence. This is useful for autonomous programs where the robot performs actions in a predefined order. However, command groups are not intended to loop in order to listen for user response. If we continue using a command group to schedule teleop commands, we will need to create our own  custom scheduler using command groups.

CommandBasedRobot (and all other Robot frameworks) have their own built-in Scheduler to listen for joystick inputs and schedule the appropriate commands. setDefaultCommand() will set the given command to always run unless another command requiring the same subsystem is called.